### PR TITLE
Solve uint/int comparison warnings

### DIFF
--- a/src/libcal/tests/cal_rng_test.hpp
+++ b/src/libcal/tests/cal_rng_test.hpp
@@ -73,7 +73,7 @@ TEST_F(CALrngTest, reprod) {
 TEST_F(CALrngTest, reprod_multi) {
     // Use one stream per thread
     auto & env = cal::Environment::get();
-    int nstream = env.max_threads();
+    size_t nstream = env.max_threads();
 
     // The data buffer we will process in segments
     size_t nfull = nstream * size;
@@ -134,7 +134,7 @@ TEST_F(CALrngTest, uniform11) {
 TEST_F(CALrngTest, uniform11_multi) {
     // Use one stream per thread
     auto & env = cal::Environment::get();
-    int nstream = env.max_threads();
+    size_t nstream = env.max_threads();
 
     // The data buffer we will process in segments
     size_t nfull = nstream * size;
@@ -195,7 +195,7 @@ TEST_F(CALrngTest, uniform01) {
 TEST_F(CALrngTest, uniform01_multi) {
     // Use one stream per thread
     auto & env = cal::Environment::get();
-    int nstream = env.max_threads();
+    size_t nstream = env.max_threads();
 
     // The data buffer we will process in segments
     size_t nfull = nstream * size;
@@ -256,7 +256,7 @@ TEST_F(CALrngTest, uint64) {
 TEST_F(CALrngTest, uint64_multi) {
     // Use one stream per thread
     auto & env = cal::Environment::get();
-    int nstream = env.max_threads();
+    size_t nstream = env.max_threads();
 
     // The data buffer we will process in segments
     size_t nfull = nstream * size;

--- a/src/libcal_mpi/src/simulation.cpp
+++ b/src/libcal_mpi/src/simulation.cpp
@@ -47,7 +47,7 @@ int cal::mpi_atm_sim::simulate(bool use_cache)
             slice_starts.push_back(ind_start);
             slice_stops.push_back(ind_stop);
 
-            if (slice % ntask == rank) {
+            if (slice % ntask == (size_t) rank) {
                 cholmod_sparse * cov = build_sparse_covariance(ind_start, ind_stop);
                 cholmod_sparse * sqrt_cov = sqrt_sparse_covariance(cov, ind_start, ind_stop);
                 cholmod_free_sparse(&cov, chcommon);

--- a/src/pycal/_libcal_math_healpix.cpp
+++ b/src/pycal/_libcal_math_healpix.cpp
@@ -17,7 +17,7 @@ void init_math_healpix(py::module & m) {
             py::buffer_info info_vec = vec.request();
             size_t nvec = (size_t)(info_vec.size / 3);
             if ((info_theta.size != info_phi.size) ||
-                (info_theta.size != nvec)) {
+                ( (size_t) info_theta.size != nvec)) {
                 auto log = cal::Logger::get();
                 std::ostringstream o;
                 o << "Buffer sizes are not consistent.";
@@ -62,7 +62,7 @@ void init_math_healpix(py::module & m) {
             py::buffer_info info_vec = vec.request();
             size_t nvec = (size_t)(info_vec.size / 3);
             if ((info_theta.size != info_phi.size) ||
-                (info_theta.size != nvec)) {
+                ( (size_t) info_theta.size != nvec)) {
                 auto log = cal::Logger::get();
                 std::ostringstream o;
                 o << "Buffer sizes are not consistent.";
@@ -111,7 +111,7 @@ void init_math_healpix(py::module & m) {
             size_t nvec = (size_t)(info_vec.size / 6);
             if ((info_theta.size != info_phi.size) ||
                 (info_theta.size != info_pa.size) ||
-                (info_theta.size != nvec)) {
+                ( (size_t) info_theta.size != nvec)) {
                 auto log = cal::Logger::get();
                 std::ostringstream o;
                 o << "Buffer sizes are not consistent.";
@@ -274,7 +274,7 @@ void init_math_healpix(py::module & m) {
              py::buffer_info info_vec = vec.request();
              py::buffer_info info_pix = pix.request();
              size_t nvec = (size_t)(info_vec.size / 3);
-             if (nvec != info_pix.size) {
+             if (nvec != (size_t) info_pix.size) {
                  auto log = cal::Logger::get();
                  std::ostringstream o;
                  o << "Buffer sizes are not consistent.";
@@ -311,7 +311,7 @@ void init_math_healpix(py::module & m) {
              py::buffer_info info_vec = vec.request();
              py::buffer_info info_pix = pix.request();
              size_t nvec = (size_t)(info_vec.size / 3);
-             if (nvec != info_pix.size) {
+             if (nvec != (size_t) info_pix.size) {
                  auto log = cal::Logger::get();
                  std::ostringstream o;
                  o << "Buffer sizes are not consistent.";


### PR DESCRIPTION
This PR solves some compilation warnings due to comparison of unsigned and signed int.
Tested this in a fresh singularity container and seems to work.