### PR TITLE
The opacity has been fixed

### DIFF
--- a/src/libcal/src/AATM_fun.cpp
+++ b/src/libcal/src/AATM_fun.cpp
@@ -111,7 +111,8 @@ double cal::atm_get_absorption_coefficient(double altitude,
 
     atm::SkyStatus ss = get_sky_status(altitude, temperature, pressure, freq);
     ss.setUserWH2O(pwv, "mm");
-    double opacity = ss.getWetOpacity().get();
+    // double opacity = ss.getWetOpacity().get();
+    double opacity = ss.getTotalOpacity().get();
 
     return 1 - exp(-opacity);
 }
@@ -128,7 +129,8 @@ int cal::atm_get_absorption_coefficient_vec(double altitude,
                                            freqmin, freqmax, nfreq);
     ss.setUserWH2O(pwv, "mm");
     for (size_t i = 0; i < nfreq; ++i) {
-        double opacity = ss.getWetOpacity(i).get();
+        // double opacity = ss.getWetOpacity(i).get();
+        double opacity = ss.getTotalOpacity(i).get();
         absorption[i] = 1 - exp(-opacity);
     }
 


### PR DESCRIPTION
Now, the `atm_absorption_coefficient` uses the correct opacity where the dry-air, O2 and H2O are taken into account, instead the only H2O contribute.
 