### PR TITLE
Add centos8 ohpc optimized singularity container definition file

### DIFF
--- a/singularity_container/centos8-ohpc-pycal.def
+++ b/singularity_container/centos8-ohpc-pycal.def
@@ -1,0 +1,107 @@
+bootstrap:docker
+From:centos:8
+
+%post
+
+# OpenHPC repo
+yum -y install http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm
+
+yum install -y dnf-plugins-core && \
+yum config-manager --set-enabled powertools && \
+yum upgrade -y && \
+yum -y install gnu9-compilers-ohpc openmpi4-gnu9-ohpc lmod-ohpc git cmake-ohpc fftw-gnu9-openmpi4-ohpc suitesparse-devel python3-mpi4py-gnu9-openmpi4-ohpc make openblas-gnu9-ohpc python3-devel python3-numpy-gnu9-ohpc python3-scipy-gnu9-openmpi4-ohpc python3-matplotlib python3-yaml && \
+
+. /etc/profile.d/lmod.sh
+module load gnu9 openmpi4 cmake fftw py3-mpi4py openblas py3-numpy py3-scipy
+
+pip3 install astropy healpy
+
+cd /tmp
+git clone https://github.com/hpc4cmb/libaatm.git
+cd libaatm
+mkdir build
+cd build
+cmake .. && make -j$(nproc) && make install
+
+echo /usr/local/lib64/ > /etc/ld.so.conf.d/local.conf
+ldconfig
+
+cd /tmp
+git clone https://github.com/cmbgroundbased/cal.git
+cd cal
+git submodule update --init --recursive
+mkdir build
+cd build
+cmake .. && make -j$(nproc) && make install
+
+yum -y remove git cmake-ohpc 
+yum -y autoremove
+yum clean all
+
+cat << EOF > /etc/profile.d/lmod.sh
+#!/bin/sh
+# -*- shell-script -*-
+########################################################################
+#  This is the system wide source file for setting up
+#  modules:
+#
+########################################################################
+
+# NOOP if running under known resource manager
+if [[ ! -z "\$SLURM_NODELIST" && -z "\$SINGULARITY_CONTAINER" ]];then
+     return
+fi
+
+if [[ ! -z "\$PBS_NODEFILE" && -z "\$SINGULARITY_CONTAINER" ]];then
+    return
+fi
+
+export LMOD_SETTARG_CMD=":"
+export LMOD_FULL_SETTARG_SUPPORT=no
+export LMOD_COLORIZE=no
+export LMOD_PREPEND_BLOCK=normal
+
+if [ \$EUID -eq 0 ]; then
+    export MODULEPATH=/opt/ohpc/admin/modulefiles:/opt/ohpc/pub/modulefiles
+else
+    export MODULEPATH=/opt/ohpc/pub/modulefiles
+fi
+
+export BASH_ENV=/opt/ohpc/admin/lmod/lmod/init/bash
+
+# Initialize modules system
+. /opt/ohpc/admin/lmod/lmod/init/bash >/dev/null
+
+if [[ -n "\$SINGULARITY_CONTAINER" ]];then
+    module purge
+    clearMT
+fi
+
+# Load baseline OpenHPC environment
+module try-add ohpc
+
+EOF
+
+cat << EOF > /etc/profile.d/z01_lmod_load_default.sh
+if [ -z "\$__Init_Default_Modules" ]; then
+	export __Init_Default_Modules=1;
+	module --initial_load --no_redirect restore
+else
+	module refresh
+fi
+
+EOF
+
+echo 'export LMOD_SYSTEM_DEFAULT_MODULES="gnu9 openmpi4 fftw py3-mpi4py openblas py3-numpy py3-scipy"' > /etc/profile.d/a01_lmod_set_default.sh
+
+# verification
+ls -l /opt/ohpc/pub
+
+# build info
+echo "Timestamp:" `date --utc` | tee /image-build-info.txt
+
+%runscript
+exec bash -l -c "$@"
+
+
+


### PR DESCRIPTION
This PR adds a `singularity` definition file for creating a `pycal` container optimized for ohpc. It is useful for `MPI` parallelization with Infiniband on some cluster (eg. UNIMI INDACO).